### PR TITLE
Added null value support for TikTokAgeGroup property in Adgroup.cs

### DIFF
--- a/src/TikTok.ApiClient/Entities/Adgroup.cs
+++ b/src/TikTok.ApiClient/Entities/Adgroup.cs
@@ -166,7 +166,7 @@ namespace TikTok.ApiClient.Entities
 
         public List<AgeGroups> TikTokAgeGroups
         {
-            get { return this.Age.Select(item => (AgeGroups) Enum.Parse(typeof(AgeGroups), item)).ToList(); }
+            get { return this.Age?.Select(item => (AgeGroups) Enum.Parse(typeof(AgeGroups), item)).ToList(); }
         }
 
         /// <summary>


### PR DESCRIPTION
changed `this.Age.Select` to `this.Age?.Select` to support null values in `TikTokAgeGroup` property of `Adgroup.cs`